### PR TITLE
addition test code for getting and setting customer payment_type

### DIFF
--- a/Tests/test_customer.py
+++ b/Tests/test_customer.py
@@ -29,20 +29,59 @@ class TestPaymentMethods(unittest.TestCase):
 
 	def test_create_payment_type(self):
 
-		self.payment_type = {"account_name": "MasterCard", "account_number": "123456789098"}
 		create_customer(self.customer["name"], self.customer['address'], self.customer["city"], self.customer["c_state"], self.customer["zipcode"], self.customer["phone"])
 		customer_id = get_customer_id
-
 		self.assertIsNotNone(customer_id)
 
-		activate_customer(2)
-
+		activate_customer(1)
 		active_customer = activate_customer(self)
-
 		self.assertIsNotNone(active_customer)
 
 		create_payment_type(self.payment_type['account_name'], self.payment_type['account_number'], active_customer)
-
-		payment_id = get_payment_type(self.payment_type['account_name'], self.payment_type['account_number'], active_customer)
-
+		payment_id = get_payment_type(self.payment_type['account_name'], self.payment_type['account_number'])
 		self.assertIsNotNone(payment_id)
+
+	def test_get_all_payment_types_for_customer(self):
+		create_customer(self.customer["name"], self.customer['address'], self.customer["city"], self.customer["c_state"], self.customer["zipcode"], self.customer["phone"])
+		customer_id = get_customer_id
+
+		create_payment_type(self.payment_type['account_name'], self.payment_type['account_number'], customer_id)
+		all_customer_payment_types = get_customer_payment_type(customer_id)
+		self.assertTrue(len(all_customer_payment_types) > 0)
+
+
+
+	def test_select_payment_type(self):
+		create_customer(self.customer["name"], self.customer['address'], self.customer["city"], self.customer["c_state"], self.customer["zipcode"], self.customer["phone"])
+		customer_id = get_customer_id
+		self.assertIsNotNone(customer_id)
+
+		activate_customer(1)
+		active_customer = activate_customer(self)
+		self.assertIsNotNone(active_customer)
+
+		create_payment_type(self.payment_type['account_name'], self.payment_type['account_number'], active_customer)
+		payment_id = get_customer_payment_type(customer_id)
+		self.assertIsNotNone(payment_id)
+
+		customer_payment_types = get_customer_payment_type(active_customer)
+		self.assertIsNotNone(customer_payment_types)
+
+		selected_payment_type = set_payment_type(payment_id)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/models/payment_types.py
+++ b/models/payment_types.py
@@ -1,5 +1,12 @@
+
 def create_payment_type(account_name, account_number, active_customer):
 	pass
 
-def get_payment_type(account_name, account_number, active_customer):
-	return 2
+def get_payment_type(account_name, account_number):
+	return 1
+
+def get_customer_payment_type(customer_id):
+	return [("MasterCard", "123456789098")]
+
+def set_payment_type(payment_id):
+	pass


### PR DESCRIPTION
# Overview
  - Built test methods for getting all customer created payment types and selecting a payment type to use for ordering.

## Changed Content
  - Added two new methods in ```payment_types.py```
  - Added a new test method in ```test_customer.py```

## Completed/Still Needed
  - All tests pass with the most basic lines of code.
  - Implementation code for ```payment_type.py``` methods may start to be written

## Testing
  - New test methods: 
    -```test_get_all_payment_types_for_customer``` tests that a customer created a payment type and that it's being returned based on the customer_id
    -```test_select_payment_type``` tests that a single payment type is selected for creating an order

## Documentation
  - None